### PR TITLE
Fix broken images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Hi there 👋
 
-![Hello from dotnet bot](https://github.com/dotnet/brand/blob/master/dotnet-bot-illustrations/dotnet-bot/dotnet-bot_presenting.png "Dotnet-bot-presenting")
+![Hello from dotnet bot](https://github.com/dotnet/brand/blob/main/dotnet-bot-illustrations/dotnet-bot/dotnet-bot_presenting.png "Dotnet-bot-presenting")
 
 - :books: I spend my days working on [dotnet docs](https://github.com/dotnet/docs). My primary focus is the C# language. 
 - :earth_americas: I'm also on the board for the [Humanitarian toolbox](https://github.com/htbox), where we create software that aids relief organizations
@@ -8,4 +8,5 @@
 - :ear: Send feedback here, or reach out on twitter.
 
 Later
-![dotnet bot mic drop](https://github.com/dotnet/brand/blob/master/dotnet-bot-illustrations/dotnet-bot/dotnet-bot_mic-drop.png "Dotnet-bot-mic-drop")
+
+![dotnet bot mic drop](https://github.com/dotnet/brand/blob/main/dotnet-bot-illustrations/dotnet-bot/dotnet-bot_mic-drop.png "Dotnet-bot-mic-drop")


### PR DESCRIPTION
Was checking out your profile after opening issue in docs repo and noticed broken images. Looks like Microsoft recently adopted the "main" convention for default branches which broke your profile's README. 